### PR TITLE
Resolve issues with empty protobuf argument.

### DIFF
--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -51,7 +51,7 @@ final class Invoker implements InvokerInterface
 
             /** @var Message $in */
             $in = new $class();
-            if (!empty($body)) {
+            if ($body !== null) {
                 $in->mergeFromString($body);
             }
 

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -33,7 +33,7 @@ final class Invoker implements InvokerInterface
         try {
             return $out->serializeToString();
         } catch (\Throwable $e) {
-            throw new InvokeException($e->getMessage(), StatusCode::INTERNAL, $e);
+            throw new InvokeException($e->getMessage(), StatusCode::INTERNAL, [], $e);
         }
     }
 
@@ -51,11 +51,13 @@ final class Invoker implements InvokerInterface
 
             /** @var Message $in */
             $in = new $class();
-            $in->mergeFromString($body);
+            if (!empty($body)) {
+                $in->mergeFromString($body);
+            }
 
             return $in;
         } catch (\Throwable $e) {
-            throw new InvokeException($e->getMessage(), StatusCode::INTERNAL, $e);
+            throw new InvokeException($e->getMessage(), StatusCode::INTERNAL, [], $e);
         }
     }
 }


### PR DESCRIPTION
- Comply with GRPCException constructor signature when rethrowing Inv…
- Prevent "Google\Protobuf\Internal\Message::mergeFromString() expects parameter 1 to be string, null given" when body is empty for empty proto argument.

Example Proto - ListTask is the culprit

```
syntax = "proto3";

package demo.service;

import "google/protobuf/empty.proto";

service ToDo {
    rpc AddTask (Task) returns (Task) {
    }
    rpc ListTask (google.protobuf.Empty) returns (ListTaskResponse) {
    }
    rpc CompleteTask (CompleteTaskRequest) returns (Task) {
    }
    rpc GetTask (GetTaskRequest) returns (Task) {
    }
}

message Task {
    string id = 1;
    string label = 2;
    enum TaskState {
        PENDING = 0;
        COMPLETED = 1;
    }
    TaskState status = 3;
}

message ListTaskResponse {
    repeated Task tasks = 1;
}

message CompleteTaskRequest {
    string task_id = 1;
}

message GetTaskRequest {
    string task_id = 1;
}
```