### PR TITLE
Bumping version of roadrunner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/polyfill-php80": "^1.22",
         "symfony/polyfill-php73": "^1.22",
         "google/protobuf": "^3.7",
-        "spiral/roadrunner": "^1.8"
+        "spiral/roadrunner": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0",


### PR DESCRIPTION
Hey! I want to use at the same time laravel-roadrunner-bridge and php-grpc packages in one project. 
But I see version conflicts. So now im trying to resolve this conflict.